### PR TITLE
Improved Support for Distributed Training

### DIFF
--- a/nfp/layers/wrappers.py
+++ b/nfp/layers/wrappers.py
@@ -14,6 +14,7 @@ Peter, 11/9/2018.
 
 from keras.layers import GRUCell, LSTMCell
 
+
 class GRUStep(GRUCell): 
     def build(self, input_shape):
         GRUCell.build(self, input_shape[0])

--- a/nfp/models/models.py
+++ b/nfp/models/models.py
@@ -1,5 +1,6 @@
 from keras.models import Model
 
+
 class GraphModel(Model):
     """ This is a simple modification of the Keras `Model` class to avoid
     checking each input for a consistent batch_size dimension. Should work as

--- a/tests/preprocessing/test_sequence.py
+++ b/tests/preprocessing/test_sequence.py
@@ -7,16 +7,20 @@ from rdkit.Chem import AllChem
 
 from nfp.preprocessing import SmilesPreprocessor, GraphSequence
 
+
 def test_sequence(get_2d_data):
-    
+
+    # Unpack the test data (from a module-level fixture)
     inputs, y = get_2d_data
 
+    # Test counting the number of batches
     assert len(GraphSequence(inputs, y, batch_size=5, final_batch=True)) == 11
     assert len(GraphSequence(inputs, y, batch_size=5, final_batch=False)) == 11
 
     assert len(GraphSequence(inputs, y, batch_size=10, final_batch=True)) == 6
     assert len(GraphSequence(inputs, y, batch_size=10, final_batch=False)) == 5
 
+    # Test that atoms are assigned to the proper molecule
     seq = GraphSequence(inputs, y, batch_size=10, final_batch=False)
     for batch in seq:
         assert batch[0]['node_graph_indices'][-1] == 9
@@ -25,17 +29,26 @@ def test_sequence(get_2d_data):
         assert len(batch[0]['node_graph_indices']) == len(batch[0]['atom'])
         assert len(batch[0]['bond_graph_indices']) == len(batch[0]['bond'])
 
+    # Test results are identical w/ and w/o output data
     np.testing.assert_allclose(
         GraphSequence(inputs, y, batch_size=3, shuffle=False)[0][0]['atom'][:10],
         GraphSequence(inputs, y=None, batch_size=5, shuffle=False)[0]['atom'][:10])
 
+    # Verify that shuffling actually changes the order of entries
     seq1 = GraphSequence(inputs, y, batch_size=3, shuffle=True)
     seq2 = GraphSequence(inputs, y, batch_size=3, shuffle=True)
     seq2.on_epoch_end()
 
     assert ~np.allclose(seq1[0][1], seq2[0][1])
 
+    # Verify that shuffling with an offset yields the expected result
+    #   Offset by the equivalent of one batch
+    seq3 = GraphSequence(inputs, y, batch_size=3, shuffle_offset=3)
+    seq3.on_epoch_end()
 
+    assert np.allclose(seq2[0][1], seq3[1][1])
+
+    # Check that molecules are concatenated in the proper order and connectivity are updated
     seq1 = GraphSequence(inputs, y=None, batch_size=1, shuffle=False)
     seq2 = GraphSequence(inputs, y=None, batch_size=3, shuffle=False)
     
@@ -55,12 +68,13 @@ def test_sequence(get_2d_data):
     all_batches_except_last = seq2[:-1]
     assert num_atoms_except_last == len(all_batches_except_last['atom'])
 
-
+    # Test output is a 2D array
     y_list = [y, y + 1]
     seq_list = GraphSequence(inputs, y_list, batch_size=5, final_batch=True)
     assert len(seq_list[0][1][0]) == 5
     assert np.allclose(seq_list[0][1][0], seq_list[0][1][1] - 1)
 
+    # Test outputs as a dictionary
     y_dict = {'y1': y, 'y2': y + 1}
     seq_dict = GraphSequence(inputs, y_dict, batch_size=5, final_batch=True)
     assert len(seq_dict[0][1]['y1']) == 5


### PR DESCRIPTION
This PR adds support for ensuring that each replica has different training data during data-parallel training. This is accomplished by setting the same random seed for each `GraphSequence` and shifting the training data after shuffling.